### PR TITLE
added tests dir to files in pre commit hooks

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,5 +4,5 @@
   language: docker
   description: 'Formats DBT with `dbt-formatter`'
   types: [sql]
-  files: ".*/(?:models|macros|snapshots)/.*/.*.sql"
+  files: ".*/(?:models|macros|snapshots|tests)/.*/.*.sql"
   require_serial: true


### PR DESCRIPTION
added `tests` to files in .pre-commit-hooks.yaml so that files in tests directories will be checked and/or reformatted.